### PR TITLE
[Feature] Fix the types for Maybe.prop

### DIFF
--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -228,11 +228,10 @@ export default class Maybe<A> implements Eq<Maybe<A>>, Monad<A>, Extend<A> {
   apply = <B>(m: Maybe<(value: A) => B>): Maybe<B> => this.then(val => m.map(func => func(val)))
 
   /**
-   * Returns a Maybe for the value at the given key. Currently, we will have a pass an explicit type
-   * here to override the one that TypeScript infers. Hopefully this will get better over time.
+   * Returns a Maybe for the value at the given key.
    */
-  prop = <B extends A[keyof A]>(key: keyof A): Maybe<B> => this.then(
-    val => (val && key in val) ? Just(val[key] as B) : Nothing()
+  prop = <P extends keyof A>(key: P): Maybe<A[P]> => this.then(
+    val => (val && key in val) ? Just(val[key]) : Nothing()
   )
 
   /**

--- a/src/__tests__/Maybe.test.ts
+++ b/src/__tests__/Maybe.test.ts
@@ -130,7 +130,7 @@ describe('Maybe', () => {
 
   describe('prop()', () => {
     it('returns a Maybe for the value at the specified key of an object', () => {
-      const m = Just({test: 123}).prop('test')
+      const m = Just({test: 123, variation: 'string'}).prop('test')
 
       expect(m.getOrThrow()).toEqual(123)
     })
@@ -156,7 +156,7 @@ describe('Maybe', () => {
         id: 1
       }
 
-      const maybeElf = Just(cottage).prop<Shelf>('shelf').prop<Elf>('elf')
+      const maybeElf = Just(cottage).prop('shelf').prop('elf')
 
       const defaultElf = {pointyEars: false}
 


### PR DESCRIPTION
Changes the type signature of `Maybe.prop` from:

```ts
prop = <B extends A[keyof A]>(key: keyof A) => Maybe<B>
```

To:

```ts
prop = <P extends keyof A>(key: P) => Maybe<A[P]>
```

This fixes the types on `prop` to make them more automatic, but breaks existing usages.